### PR TITLE
Add Python Comb Sort & add link Python Heap Sort no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2696,8 +2696,8 @@ Com o objetivo de alcançar uma abrangência maior e encorajar novas pessoas a c
                 </a>
             </td>
             <td> <!-- Python -->
-                <a href="./CONTRIBUTING.md">
-                    <img align="center" height="25" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" />
+                <a href="./src/python/comb_sort.py">
+                    <img align="center" height="25" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" />
                 </a>
             </td>
             <td> <!-- Go -->
@@ -2870,8 +2870,8 @@ Com o objetivo de alcançar uma abrangência maior e encorajar novas pessoas a c
                 </a>
             </td>
             <td> <!-- Python -->
-                <a href="./CONTRIBUTING.md">
-                    <img align="center" height="25" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" />
+                <a href="./src/python/heap_sort.py">
+                    <img align="center" height="25" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" />
                 </a>
             </td>
             <td> <!-- Go -->

--- a/src/python/comb_sort.py
+++ b/src/python/comb_sort.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#----------------------------------------------------------------------------
+# Created By  : octaviolage
+# Created Date: 2022-05-15
+# version ='1.0'
+# -------------------------------
+def comb_sort(arr: list) -> list:
+    """
+    Implementação de um algoritmo de ordenação combinada.
+    """
+    gap = len(arr)
+    shrink = 1.3
+    swapped = True
+    while gap > 1 or swapped:
+        gap = int(gap / shrink)
+        if gap < 1:
+            gap = 1
+        swapped = False
+        for i in range(len(arr) - gap):
+            if arr[i] > arr[i + gap]:
+                arr[i], arr[i + gap] = arr[i + gap], arr[i]
+                swapped = True
+    return arr
+
+if __name__ == '__main__':
+    from random import randint
+    my_list = [randint(0, 100) for _ in range(10)]
+    print(f'Lista: {my_list}')
+    print(f'Ordenada: {comb_sort(my_list)}')


### PR DESCRIPTION
Vi que no README não constava Comb Sort e Heap Sort em python, por isso resolvi adicionar. Porém o Heap Sort já havia sido feito e só faltava adicionar no README.md

PS: Coloquei como meta contribuir mais em repositórios públicos como esse, por isso e se me permitir, estarei contribuindo aqui mais vezes.