### PR TITLE
Add deque in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -1713,7 +1713,7 @@ Com o objetivo de alcançar uma abrangência maior e encorajar mais pessoas a co
                 </a>
             </td>
             <td> <!-- Go -->
-                <a href="./CONTRIBUTING.md">
+                <a href="./src/go/deque.go">
                     <img align="center" height="25" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" />
                 </a>
             </td>

--- a/README.md
+++ b/README.md
@@ -1714,7 +1714,7 @@ Com o objetivo de alcançar uma abrangência maior e encorajar mais pessoas a co
             </td>
             <td> <!-- Go -->
                 <a href="./src/go/deque.go">
-                    <img align="center" height="25" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/github/github-original.svg" />
+                    <img align="center" height="25" src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/go/go-original.svg" />
                 </a>
             </td>
             <td> <!-- Ruby -->

--- a/src/go/deque.go
+++ b/src/go/deque.go
@@ -1,9 +1,6 @@
 package main
 
-import (
-	"github.com/stretchr/testify/assert"
-	"testing"
-)
+import "fmt"
 
 type Deque struct {
 	Store []int
@@ -43,24 +40,26 @@ func (deque *Deque) LPop() *int {
 	return &element
 }
 
-func TestDeque(t *testing.T) {
+func main() {
 	deque := Deque{}
+
+	fmt.Println("RPush(1, 2, 3)")
 
 	deque.RPush(1)
 	deque.RPush(2)
 	deque.RPush(3)
 
-	assert.Equal(t, 3, *deque.RPop())
-	assert.Equal(t, 2, *deque.RPop())
-	assert.Equal(t, 1, *deque.RPop())
-	assert.Nil(t, deque.RPop())
+	fmt.Println("RPop(): ", *deque.RPop())
+	fmt.Println("RPop(): ", *deque.RPop())
+	fmt.Println("RPop(): ", *deque.RPop())
+
+	fmt.Println("LPush(1, 2, 3)")
 
 	deque.LPush(1)
 	deque.LPush(2)
 	deque.LPush(3)
 
-	assert.Equal(t, 1, *deque.RPop())
-	assert.Equal(t, 2, *deque.RPop())
-	assert.Equal(t, 3, *deque.RPop())
-	assert.Nil(t, deque.RPop())
+	fmt.Println("RPop(): ", *deque.RPop())
+	fmt.Println("RPop(): ", *deque.RPop())
+	fmt.Println("RPop(): ", *deque.RPop())
 }

--- a/src/go/deque.go
+++ b/src/go/deque.go
@@ -1,64 +1,66 @@
+package main
+
 import (
-  "testing"
-  "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 type Deque struct {
-  Store []int
+	Store []int
 }
 
 // Time complexity: O(1)
 func (deque *Deque) RPush(element int) {
-  deque.Store = append(deque.Store, element)
+	deque.Store = append(deque.Store, element)
 }
 
 // Time complexity: O(n)
 func (deque *Deque) LPush(element int) {
-  deque.Store = append([]int{element}, deque.Store...)
+	deque.Store = append([]int{element}, deque.Store...)
 }
 
 // Time complexity: O(1)
 func (deque *Deque) RPop() *int {
-  if len(deque.Store) == 0 {
-    return nil
-  }
+	if len(deque.Store) == 0 {
+		return nil
+	}
 
-  element := deque.Store[len(deque.Store) - 1]
-  deque.Store = deque.Store[:len(deque.Store) - 1]
+	element := deque.Store[len(deque.Store)-1]
+	deque.Store = deque.Store[:len(deque.Store)-1]
 
-  return &element
+	return &element
 }
 
 // Time complexity: O(n)
 func (deque *Deque) LPop() *int {
-  if len(deque.Store) == 0 {
-    return nil
-  }
+	if len(deque.Store) == 0 {
+		return nil
+	}
 
-  element := deque.Store[0]
-  deque.Store = deque.Store[1:]
+	element := deque.Store[0]
+	deque.Store = deque.Store[1:]
 
-  return &element
+	return &element
 }
 
 func TestDeque(t *testing.T) {
-  deque := Deque{}
+	deque := Deque{}
 
-  deque.RPush(1)
-  deque.RPush(2)
-  deque.RPush(3)
+	deque.RPush(1)
+	deque.RPush(2)
+	deque.RPush(3)
 
-  assert.Equal(t, 3, *deque.RPop())
-  assert.Equal(t, 2, *deque.RPop())
-  assert.Equal(t, 1, *deque.RPop())
-  assert.Nil(t, deque.RPop())
+	assert.Equal(t, 3, *deque.RPop())
+	assert.Equal(t, 2, *deque.RPop())
+	assert.Equal(t, 1, *deque.RPop())
+	assert.Nil(t, deque.RPop())
 
-  deque.LPush(1)
-  deque.LPush(2)
-  deque.LPush(3)
+	deque.LPush(1)
+	deque.LPush(2)
+	deque.LPush(3)
 
-  assert.Equal(t, 1, *deque.RPop())
-  assert.Equal(t, 2, *deque.RPop())
-  assert.Equal(t, 3, *deque.RPop())
-  assert.Nil(t, deque.RPop())
+	assert.Equal(t, 1, *deque.RPop())
+	assert.Equal(t, 2, *deque.RPop())
+	assert.Equal(t, 3, *deque.RPop())
+	assert.Nil(t, deque.RPop())
 }

--- a/src/go/deque.go
+++ b/src/go/deque.go
@@ -1,0 +1,64 @@
+import (
+  "testing"
+  "github.com/stretchr/testify/assert"
+)
+
+type Deque struct {
+  Store []int
+}
+
+// Time complexity: O(1)
+func (deque *Deque) RPush(element int) {
+  deque.Store = append(deque.Store, element)
+}
+
+// Time complexity: O(n)
+func (deque *Deque) LPush(element int) {
+  deque.Store = append([]int{element}, deque.Store...)
+}
+
+// Time complexity: O(1)
+func (deque *Deque) RPop() *int {
+  if len(deque.Store) == 0 {
+    return nil
+  }
+
+  element := deque.Store[len(deque.Store) - 1]
+  deque.Store = deque.Store[:len(deque.Store) - 1]
+
+  return &element
+}
+
+// Time complexity: O(n)
+func (deque *Deque) LPop() *int {
+  if len(deque.Store) == 0 {
+    return nil
+  }
+
+  element := deque.Store[0]
+  deque.Store = deque.Store[1:]
+
+  return &element
+}
+
+func TestDeque(t *testing.T) {
+  deque := Deque{}
+
+  deque.RPush(1)
+  deque.RPush(2)
+  deque.RPush(3)
+
+  assert.Equal(t, 3, *deque.RPop())
+  assert.Equal(t, 2, *deque.RPop())
+  assert.Equal(t, 1, *deque.RPop())
+  assert.Nil(t, deque.RPop())
+
+  deque.LPush(1)
+  deque.LPush(2)
+  deque.LPush(3)
+
+  assert.Equal(t, 1, *deque.RPop())
+  assert.Equal(t, 2, *deque.RPop())
+  assert.Equal(t, 3, *deque.RPop())
+  assert.Nil(t, deque.RPop())
+}


### PR DESCRIPTION
This PR adds an implementation in Go for Deque (double-ended queue).

It covers some test scenarios using the library [testify](https://github.com/stretchr/testify) which makes easier to write unit tests in Go.