### PR TITLE
Mitigate collisions on hash table (Ruby)

### DIFF
--- a/src/ruby/hash_table.rb
+++ b/src/ruby/hash_table.rb
@@ -4,18 +4,22 @@ class HashTable
   attr_reader :hash
 
   def initialize(size = 500)
-    @hash = Array.new
+    @hash = Array.new(size) { [] }
     @size = size
   end
 
   def put(key, value)
     idx = calculate_hash(key)
-    @hash[idx] = value
+    @hash[idx] << [key, value]
   end
 
   def get(key)
     idx = calculate_hash(key)
-    @hash[idx]
+
+    bucket = @hash[idx]
+    pair = bucket.find { |pair| pair[0] == key }
+
+    pair[1] if pair
   end
 
   def delete(key)
@@ -31,11 +35,11 @@ class HashTable
 end
 
 hash = HashTable.new
-hash.put(:name, "Jane")
-hash.put(:age, 22)
+hash.put(:code, "ABC123")
+hash.put(:mode, "dark")
 
-puts hash.get(:name) # => Jane
-puts hash.get(:age) # => 22
+puts "Code is #{hash.get(:code)}" # => ABC123
+puts "Mode is #{hash.get(:mode)}" # => "dark
 
-hash.delete(:name)
-puts hash.get(:name) # => nil
+hash.delete(:code)
+puts hash.get(:code) # => nil


### PR DESCRIPTION
The first implemenation of hash table in Ruby is very simple and does not handle collisions. Now, we're adding the ability to mitigate collisions by using buckets. 

The current implementation also brings a scenario of collision: in Ruby, both "code" and "mode" lead to `400` when applying the current hashing function:

```
irb(main):001> :mode.to_s.bytes.reduce(&:*) % 500
=> 400
irb(main):002> :code.to_s.bytes.reduce(&:*) % 500
=> 400
irb(main):003>
```
